### PR TITLE
vnic: do not abort on ERANGE from vnd

### DIFF
--- a/net/vnic.c
+++ b/net/vnic.c
@@ -315,6 +315,9 @@ send:
 	if (ret == -1 && errno == EAGAIN) {
 		vnic_write_poll(vsp, 1);
 		return (0);
+	} else if (ret == -1 && errno == ERANGE) {
+		/* If it's too big or too small for the kernel, silently drop it. */
+		return (total);
 	} else if (ret == -1) {
 		abort();
 	}


### PR DESCRIPTION
When frames passed to VND are larger or smaller than the vnic's SDU, the
kernel will reject them with ERANGE. This can happen if the guest OS
passes an exceptionally large frame via virtio.

When this happens, currently, qemu calls abort(), and the entire VM
comes crashing down. And indeed until recently there was a bug in the
NetKVM virtio driver for Windows that would result in these overly-large
frames being created.

Rather than allowing an errant Windows driver to DoS the host qemu
process, this commit changes the behavior to silently discard those
frames, just as we already silently discard overly large frames
elsewhere in the same function.

This also has the effect of decoupling driver m_min_sdu/m_max_sdu values
from successful operation of qemu. That is, strangely written drivers
won't resurface this DoS (see joyent/illumos-joyent@f061e8dcd16c62605d130648b5c5e5181f6868f9), and changing
SDU bounds won't need to be coordinated either.

Besides, every other component on a network tosses out frames that are
too big or small to forward, and so this change simply follows suit.

CC @kevinmeziere